### PR TITLE
Api test

### DIFF
--- a/client/ngapp/scripts/controllers/world.js
+++ b/client/ngapp/scripts/controllers/world.js
@@ -108,36 +108,25 @@ angular.module('ooniAPIApp')
       }
 
       Report.countByCountry(query, function(report_counts) {
-          Report.blockpageDetected(function(blockpage_countries) {
-              var alpha2WithBlockingDetected = [];
-              angular.forEach(blockpage_countries, function(country) {
-                alpha2WithBlockingDetected.push(country.probe_cc);
-              });
-              $scope.reportsByCountry = report_counts;
-              angular.forEach(report_counts, function(country){
-                  $scope.worldMap.data[country.alpha3] = {
-                      reportCount: country.count,
-                      reportCountry: country.name,
-                      alpha2: country.alpha2
-                  };
-                  /*
-                  if (alpha2WithBlockingDetected.indexOf(country.alpha2) !== -1) {
-                      $scope.worldMap.data[country.alpha3]["fillKey"] = "BLOCKPAGE";
-                  } else */
-                  if (country.count < 10000) {
-                      $scope.worldMap.data[country.alpha3]["fillKey"] = "LOW";
-                  } else if (country.count < 100000) {
-                      $scope.worldMap.data[country.alpha3]["fillKey"] = "MEDIUM";
-                  } else {
-                      $scope.worldMap.data[country.alpha3]["fillKey"] = "HIGH";
-                  }
-              })
+        $scope.reportsByCountry = report_counts;
+        angular.forEach(report_counts, function(country){
+            $scope.worldMap.data[country.alpha3] = {
+                reportCount: country.count,
+                reportCountry: country.name,
+                alpha2: country.alpha2
+            };
 
-              $scope.loaded = true;
-              deferred.resolve($scope.reportsByCountry);
-          }, function(err, resp){
-            console.log(err, resp);
-          });
+            if (country.count < 10000) {
+                $scope.worldMap.data[country.alpha3]["fillKey"] = "LOW";
+            } else if (country.count < 100000) {
+                $scope.worldMap.data[country.alpha3]["fillKey"] = "MEDIUM";
+            } else {
+                $scope.worldMap.data[country.alpha3]["fillKey"] = "HIGH";
+            }
+        })
+
+        $scope.loaded = true;
+        deferred.resolve($scope.reportsByCountry);
       });
 
       return deferred.promise;

--- a/common/models/report.js
+++ b/common/models/report.js
@@ -4,7 +4,7 @@ var qs = require('qs')
 var countries = require('country-data').countries
 
 var apiClient = axios.create({
-  baseURL: 'https://api.test.ooni.io/api/', // yes, that's hardcoded
+  baseURL: 'https://api.ooni.io/api/', // yes, that's hardcoded
   timeout: 90000, // Maybe set this lower once performance is boosted
 })
 

--- a/common/models/report.js
+++ b/common/models/report.js
@@ -4,7 +4,7 @@ var qs = require('qs')
 var countries = require('country-data').countries
 
 var apiClient = axios.create({
-  baseURL: 'https://api.ooni.io/api/', // yes, that's hardcoded
+  baseURL: 'https://api.test.ooni.io/api/', // yes, that's hardcoded
   timeout: 90000, // Maybe set this lower once performance is boosted
 })
 


### PR DESCRIPTION
This switches over to using the testing API which will use the newly developed endpoints for the next gen OONI Explorer.

This allows us to get some more testing of those endpoints for OONI Explorer related access patterns.

I also drop an unnecessary request at the beginning since we don't paint the map red anymore there is no need to waste bandwidth and CPU cycles on performance a query which the result of is unused.